### PR TITLE
Desktop: Fix bug for top 5 items

### DIFF
--- a/desktop/FoodTruck.ump
+++ b/desktop/FoodTruck.ump
@@ -13,7 +13,7 @@ class FoodTruckManager {
 	1 -> * Employee employees;
 	1 -> * Supply supplies;
 	1 -> * Equipment equipment;
-	1 -> * MenuItem menuItems;
+	1 -> * FoodItem foodItems;
 }
 
 class Shift {
@@ -23,7 +23,7 @@ class Shift {
 	double numberOfHours;
 }
 
-class MenuItem {
+class FoodItem {
 	name;
 	double price;
 	int amountSold;
@@ -37,7 +37,7 @@ class Supply {
 class Equipment {
 	name;
 	int count;
-}//$?[End_of_model]$?
+}
 
 class Employee
 {
@@ -57,7 +57,7 @@ class Shift
   position 1 102 174 107;
 }
 
-class MenuItem
+class FoodItem
 {
   position 355 393 122 90;
 }
@@ -70,4 +70,4 @@ class Supply
 class Equipment
 {
   position 474 56 109 73;
-}
+}//$?[End_of_model]$?

--- a/desktop/bin/ca/mcgill/ecse321/foodtruck/persistence/data.xml
+++ b/desktop/bin/ca/mcgill/ecse321/foodtruck/persistence/data.xml
@@ -1,28 +1,27 @@
 <manager id="1">
   <employees id="2"/>
-  <shifts id="3"/>
-  <supplies id="4">
-    <ca.mcgill.ecse321.foodtruck.model.Supply id="5">
+  <supplies id="3">
+    <ca.mcgill.ecse321.foodtruck.model.Supply id="4">
       <name>Patty</name>
       <count>0</count>
     </ca.mcgill.ecse321.foodtruck.model.Supply>
   </supplies>
-  <equipment id="6">
-    <ca.mcgill.ecse321.foodtruck.model.Equipment id="7">
+  <equipment id="5">
+    <ca.mcgill.ecse321.foodtruck.model.Equipment id="6">
       <name>Spatula</name>
       <count>0</count>
     </ca.mcgill.ecse321.foodtruck.model.Equipment>
   </equipment>
-  <menuItems id="8">
-    <item id="9">
+  <foodItems id="7">
+    <item id="8">
       <name>Burger</name>
       <price>4.5</price>
       <amountSold>0</amountSold>
     </item>
-    <item id="10">
+    <item id="9">
       <name>French Fries</name>
       <price>2.0</price>
       <amountSold>0</amountSold>
     </item>
-  </menuItems>
+  </foodItems>
 </manager>

--- a/desktop/src/ca/mcgill/ecse321/foodtruck/controller/FoodTruckController.java
+++ b/desktop/src/ca/mcgill/ecse321/foodtruck/controller/FoodTruckController.java
@@ -157,7 +157,7 @@ public class FoodTruckController {
 		//sort menu items by amount sold
 		Collections.sort(topList, new Comparator<FoodItem>() {
 			@Override public int compare(FoodItem item1, FoodItem item2) {
-				return item1.getAmountSold() - item2.getAmountSold();
+				return item2.getAmountSold() - item1.getAmountSold();
 			}
 		});
 		

--- a/desktop/test/ca/mcgill/ecse321/foodtruck/controller/TestFoodTruckFoodItems.java
+++ b/desktop/test/ca/mcgill/ecse321/foodtruck/controller/TestFoodTruckFoodItems.java
@@ -2,6 +2,8 @@ package ca.mcgill.ecse321.foodtruck.controller;
 
 import static org.junit.Assert.*;
 
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -417,6 +419,43 @@ public class TestFoodTruckFoodItems {
 		
 		assertEquals(errorMessage,"Please enter an order quantity!");
 		checkResultOrderNoChange(ftms);
+	}
+	
+	@Test
+	public void testGetPopularItems() {
+		FoodTruckManager ftms = FoodTruckManager.getInstance();
+		
+		//add 6 items to menu
+		FoodItem item1 = new FoodItem("Burger", 5.00, 10);
+		ftms.addFoodItem(item1);
+		
+		FoodItem item2 = new FoodItem("Fries", 5.00, 9);
+		ftms.addFoodItem(item2);
+		
+		FoodItem item3 = new FoodItem("Shake", 5.00, 7);
+		ftms.addFoodItem(item3);
+		
+		FoodItem item4 = new FoodItem("Hot Dog", 5.00, 5);
+		ftms.addFoodItem(item4);
+		
+		FoodItem item5 = new FoodItem("Onion Ring", 5.00, 3);
+		ftms.addFoodItem(item5);
+		
+		FoodItem item6 = new FoodItem("Chips", 5.00, 0);
+		ftms.addFoodItem(item6);
+		
+		FoodTruckController ftc = new FoodTruckController();
+		
+		List<FoodItem> list = ftc.getPopularItems();
+		
+		//check top 5 items
+		assertEquals(list.size(),5);
+		assertEquals(list.get(0),item1);
+		assertEquals(list.get(1),item2);
+		assertEquals(list.get(2),item3);
+		assertEquals(list.get(3),item4);
+		assertEquals(list.get(4),item5);
+		
 	}
 	
 	private void checkResultFoodItem(String itemName, double itemPrice, FoodTruckManager ftms) {

--- a/desktop/test/ca/mcgill/ecse321/foodtruck/controller/TestFoodTruckFoodItems.java
+++ b/desktop/test/ca/mcgill/ecse321/foodtruck/controller/TestFoodTruckFoodItems.java
@@ -455,7 +455,18 @@ public class TestFoodTruckFoodItems {
 		assertEquals(list.get(2),item3);
 		assertEquals(list.get(3),item4);
 		assertEquals(list.get(4),item5);
+	}
+	
+	@Test
+	public void testGetPopularItemsNoItems() {
+		FoodTruckManager ftms = FoodTruckManager.getInstance();
 		
+		FoodTruckController ftc = new FoodTruckController();
+		
+		List<FoodItem> list = ftc.getPopularItems();
+		
+		//check top 5 items
+		assertEquals(list.size(),0);
 	}
 	
 	private void checkResultFoodItem(String itemName, double itemPrice, FoodTruckManager ftms) {


### PR DESCRIPTION
Top items would display least popular items by mistake due to the
comparator being flipped. This has been flipped and tested.